### PR TITLE
i16->f32 a bit faster and more transparent

### DIFF
--- a/src/lib/xdsp/conv_f32_i16_2.c
+++ b/src/lib/xdsp/conv_f32_i16_2.c
@@ -18,11 +18,11 @@ VWLT_ATTRIBUTE(optimize("-O3"), target("sse2"))
 DECLARE_TR_FUNC_1_1(conv_f32_i16_sse2)
 #endif
 
-#ifdef WVLT_AVX
-#define TEMPLATE_FUNC_NAME conv_f32_i16_avx
-VWLT_ATTRIBUTE(optimize("-O3"), target("avx"))
-#include "templates/conv_f32_i16_generic.t"
-DECLARE_TR_FUNC_1_1(conv_f32_i16_avx)
+#ifdef WVLT_AVX2
+#define TEMPLATE_FUNC_NAME conv_f32_i16_avx2
+VWLT_ATTRIBUTE(optimize("-O3"), target("avx2"))
+#include "templates/conv_f32_i16_avx2.t"
+DECLARE_TR_FUNC_1_1(conv_f32_i16_avx2)
 #endif
 
 
@@ -34,7 +34,7 @@ conv_function_t conv_get_f32_i16_c(generic_opts_t cpu_cap, const char** sfunc)
 
     SELECT_GENERIC_FN(fn, fname, tr_conv_f32_i16_generic, cpu_cap);
     SELECT_SSE2_FN(fn, fname, tr_conv_f32_i16_sse2, cpu_cap);
-    SELECT_AVX_FN(fn, fname, tr_conv_f32_i16_avx, cpu_cap);
+    SELECT_AVX2_FN(fn, fname, tr_conv_f32_i16_avx2, cpu_cap);
 
     if (sfunc) *sfunc = fname;
     return fn;

--- a/src/lib/xdsp/templates/conv_f32_i16_avx2.t
+++ b/src/lib/xdsp/templates/conv_f32_i16_avx2.t
@@ -1,0 +1,81 @@
+static
+void TEMPLATE_FUNC_NAME(const void *__restrict indata_p,
+                        unsigned indatabsz,
+                        void *__restrict outdata_p,
+                        unsigned outdatabsz)
+{
+    unsigned i = indatabsz;
+    if ((outdatabsz * 2) < i)
+        i = (outdatabsz * 2);
+
+    const float* indata = (const float*)indata_p;
+    int16_t* outdata = (int16_t*)outdata_p;
+    const __m256  scale = _mm256_set1_ps(1.0f / CONV_SCALE);
+
+#define CONVERT_F32_I16_BLOCK(v0, v1) \
+    { \
+        v0 = _mm256_mul_ps(v0, scale); \
+        v1 = _mm256_mul_ps(v1, scale); \
+    \
+        __m256i i0 = _mm256_cvtps_epi32(v0); \
+        __m256i i1 = _mm256_cvtps_epi32(v1); \
+    \
+        __m256i ii0 = _mm256_packs_epi32(i0, i1); \
+        ii0 = _mm256_permute4x64_epi64(ii0, _MM_SHUFFLE(3,1,2,0)); \
+    \
+        _mm256_storeu_si256((__m256i *)outdata, ii0); \
+        outdata += 16; \
+    }
+// CONVERT_F32_I16_BLOCK end
+
+    __m256  v0, v1, v2, v3;
+
+    for (; i >= 32*4; i -= 32*4)
+    {
+        v0 = _mm256_loadu_ps(indata +  0);
+        v1 = _mm256_loadu_ps(indata +  8);
+        v2 = _mm256_loadu_ps(indata + 16);
+        v3 = _mm256_loadu_ps(indata + 24);
+        indata += 32;
+
+        CONVERT_F32_I16_BLOCK(v0, v1);
+        CONVERT_F32_I16_BLOCK(v2, v3);
+    }
+
+    for (; i >= 32*2; i -= 32*2)
+    {
+        v0 = _mm256_loadu_ps(indata +  0);
+        v1 = _mm256_loadu_ps(indata +  8);
+        indata += 16;
+
+        CONVERT_F32_I16_BLOCK(v0, v1);
+    }
+
+#undef CONVERT_F32_I16_BLOCK
+#undef I16RND
+#define I16RND(x) x > 0 ? (int16_t)(x + 0.5f) : (int16_t)(x - 0.5f)
+
+    for (; i >= 16; i -= 16, indata += 4, outdata += 4)
+    {
+        float fa = indata[0] / CONV_SCALE;
+        float fb = indata[1] / CONV_SCALE;
+        float fc = indata[2] / CONV_SCALE;
+        float fd = indata[3] / CONV_SCALE;
+
+        int16_t a = I16RND(fa);
+        int16_t b = I16RND(fb);
+        int16_t c = I16RND(fc);
+        int16_t d = I16RND(fd);
+
+        uint64_t v = (uint64_t)(uint16_t)a | ((uint64_t)(uint16_t)b << 16) | ((uint64_t)(uint16_t)c << 32) | ((uint64_t)(uint16_t)d << 48);
+        *(int64_t*)outdata = v;
+    }
+
+    for (; i >= 4; i -= 4)
+    {
+        float a = *(indata++) / CONV_SCALE;
+        *(outdata++) = I16RND(a);
+    }
+}
+
+#undef TEMPLATE_FUNC_NAME

--- a/src/lib/xdsp/templates/conv_i16_f32_avx2.t
+++ b/src/lib/xdsp/templates/conv_i16_f32_avx2.t
@@ -4,112 +4,57 @@ void TEMPLATE_FUNC_NAME(const int16_t *__restrict indata,
                         float *__restrict outdata,
                         unsigned outdatabsz)
 {
-#define inscale      CONV_SCALE
-#define SCALE2(x)    ((x)/65536)
-
   size_t i = indatabsz;
   if ((outdatabsz / 2) < i)
     i = (outdatabsz / 2);
 
   const __m256i* vp = (const __m256i* )indata;
-  __m256i d0, d1, d2, d3;
-  __m256 f0, f1, f2, f3;
-  __m256 p0, p1, p2, p3;
-  __m256 scale = _mm256_set_ps(SCALE2(inscale), SCALE2(inscale), SCALE2(inscale), SCALE2(inscale), SCALE2(inscale), SCALE2(inscale), SCALE2(inscale), SCALE2(inscale));
-  __m256i t0;
-  __m256i t1;
+  __m256 scale = _mm256_set1_ps(CONV_SCALE);
+  __m256i t0, t1, t2;
 
-  if (i >= 64) {
-      t0 = _mm256_loadu_si256(vp++); // Latency 7
-      t1 = _mm256_loadu_si256(vp++); // Latency 7
+#define CONVERT_I16_F32_BLOCK(reg) \
+    {   \
+        __m256i d0 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(reg));         \
+        __m256i d1 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(reg, 1));    \
+        \
+        __m256 f0 = _mm256_cvtepi32_ps(d0); \
+        __m256 f1 = _mm256_cvtepi32_ps(d1); \
+        \
+        f0 = _mm256_mul_ps(f0, scale);  \
+        f1 = _mm256_mul_ps(f1, scale);  \
+        \
+        _mm256_storeu_ps(outdata, f0); outdata += 8;    \
+        _mm256_storeu_ps(outdata, f1); outdata += 8;    \
+    }
+// CONVERT_I16_F32_BLOCK end
 
-      for (; i >= 128; i -= 64) {
-          d0 = _mm256_unpacklo_epi16(_mm256_set1_epi16(0), t0); // 0 1 2 3 8 9 A B
-          d1 = _mm256_unpackhi_epi16(_mm256_set1_epi16(0), t0); // 4 5 6 7 C D E F
-          d2 = _mm256_unpacklo_epi16(_mm256_set1_epi16(0), t1);
-          d3 = _mm256_unpackhi_epi16(_mm256_set1_epi16(0), t1);
+  for(; i >= 96; i -= 96)
+  {
+     t0 = _mm256_loadu_si256(vp++);
+     t1 = _mm256_loadu_si256(vp++);
+     t2 = _mm256_loadu_si256(vp++);
 
-          t0 = _mm256_load_si256(vp++);   // Latency 7
-          t1 = _mm256_load_si256(vp++);   // Latency 7
-
-          f0 = _mm256_cvtepi32_ps(d0);    // Latency 3-4
-          f1 = _mm256_cvtepi32_ps(d1);    // Latency 3-4
-          f2 = _mm256_cvtepi32_ps(d2);    // Latency 3-4
-          f3 = _mm256_cvtepi32_ps(d3);    // Latency 3-4
-
-          f0 = _mm256_mul_ps(f0, scale);  // Latency 4-5
-          f1 = _mm256_mul_ps(f1, scale);  // Latency 4-5
-          f2 = _mm256_mul_ps(f2, scale);  // Latency 4-5
-          f3 = _mm256_mul_ps(f3, scale);  // Latency 4-5
-
-          p0 = _mm256_permute2f128_ps(f0, f1, 0x20);  // Latency 3
-          p1 = _mm256_permute2f128_ps(f0, f1, 0x31);  // Latency 3
-          p2 = _mm256_permute2f128_ps(f2, f3, 0x20);  // Latency 3
-          p3 = _mm256_permute2f128_ps(f2, f3, 0x31);  // Latency 3
-
-          _mm256_storeu_ps(outdata, p0); outdata += 8;
-          _mm256_storeu_ps(outdata, p1); outdata += 8;
-          _mm256_storeu_ps(outdata, p2); outdata += 8;
-          _mm256_storeu_ps(outdata, p3); outdata += 8;
-      }
-
-      i -= 64;
-
-      // Last portion of 64 + bytes % 64
-      d0 = _mm256_unpacklo_epi16(_mm256_set1_epi16(0), t0);
-      d1 = _mm256_unpackhi_epi16(_mm256_set1_epi16(0), t0);
-      d2 = _mm256_unpacklo_epi16(_mm256_set1_epi16(0), t1);
-      d3 = _mm256_unpackhi_epi16(_mm256_set1_epi16(0), t1);
-
-      if (i >= 32) {
-          t0 = _mm256_loadu_si256(vp++);
-      }
-
-      f0 = _mm256_cvtepi32_ps(d0);    // Latency 3
-      f1 = _mm256_cvtepi32_ps(d1);    // Latency 3
-      f2 = _mm256_cvtepi32_ps(d2);    // Latency 3
-      f3 = _mm256_cvtepi32_ps(d3);    // Latency 3
-
-      f0 = _mm256_mul_ps(f0, scale);  // Latency 5
-      f1 = _mm256_mul_ps(f1, scale);
-      f2 = _mm256_mul_ps(f2, scale);  // Latency 5
-      f3 = _mm256_mul_ps(f3, scale);
-
-      p0 = _mm256_permute2f128_ps(f0, f1, 0x20); 
-      p1 = _mm256_permute2f128_ps(f0, f1, 0x31);
-      p2 = _mm256_permute2f128_ps(f2, f3, 0x20);
-      p3 = _mm256_permute2f128_ps(f2, f3, 0x31);
-
-      _mm256_storeu_ps(outdata, p0); outdata += 8;
-      _mm256_storeu_ps(outdata, p1); outdata += 8;
-      _mm256_storeu_ps(outdata, p2); outdata += 8;
-      _mm256_storeu_ps(outdata, p3); outdata += 8;
-
-      if (i == 0)
-          return;
-  } else if (i >= 32) {
-      t0 = _mm256_loadu_si256(vp++);
+     CONVERT_I16_F32_BLOCK(t0);
+     CONVERT_I16_F32_BLOCK(t1);
+     CONVERT_I16_F32_BLOCK(t2);
   }
 
-  if (i >= 32) {
-      i -= 32;
+  for(; i >= 64; i -= 64)
+  {
+     t0 = _mm256_loadu_si256(vp++);
+     t1 = _mm256_loadu_si256(vp++);
 
-      // Last portion of 64 + bytes % 64
-      d0 = _mm256_unpacklo_epi16(_mm256_set1_epi16(0), t0);
-      d1 = _mm256_unpackhi_epi16(_mm256_set1_epi16(0), t0);
-
-      f0 = _mm256_cvtepi32_ps(d0);    // Latency 3
-      f1 = _mm256_cvtepi32_ps(d1);    // Latency 3
-
-      f0 = _mm256_mul_ps(f0, scale);  // Latency 5
-      f1 = _mm256_mul_ps(f1, scale);
-
-      p0 = _mm256_permute2f128_ps(f0, f1, 0x20); 
-      p1 = _mm256_permute2f128_ps(f0, f1, 0x31);
-
-      _mm256_storeu_ps(outdata, p0); outdata+=8;
-      _mm256_storeu_ps(outdata, p1); outdata+=8;
+     CONVERT_I16_F32_BLOCK(t0);
+     CONVERT_I16_F32_BLOCK(t1);
   }
+
+  for(; i >= 32; i -= 32)
+  {
+     t0 = _mm256_loadu_si256(vp++);
+     CONVERT_I16_F32_BLOCK(t0);
+  }
+
+#undef CONVERT_I16_F32_BLOCK
 
   if (i > 0) {
       const int16_t *ldw = (const int16_t *)vp;

--- a/src/lib/xdsp/utests/CMakeLists.txt
+++ b/src/lib/xdsp/utests/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(TEST_SUIT_SRCS
     xdsp_utest_suite.c
     conv_i16_f32_utest.c
+    conv_f32_i16_utest.c
     conv_i12_f32_utest.c
     conv_ci12_2cf32_utest.c
     conv_f32_i12_utest.c
@@ -16,6 +17,7 @@ set(TEST_SUIT_SRCS
     ../fftad_functions.c
     ../rtsa_functions.c
     ../conv_i16_f32_2.c
+    ../conv_f32_i16_2.c
     ../conv_i12_f32_2.c
     ../conv_ci12_2cf32_2.c
     ../conv_f32_i12_2.c
@@ -24,7 +26,7 @@ set(TEST_SUIT_SRCS
 )
 
 if(WVLT_ARCH_X86 OR WVLT_ARCH_X86_64)
-    add_definitions("-mavx2 -mfma")
+    add_definitions("-msse4.1")
 endif()
 
 add_definitions("-O3")

--- a/src/lib/xdsp/utests/conv_f32_i16_utest.c
+++ b/src/lib/xdsp/utests/conv_f32_i16_utest.c
@@ -1,0 +1,175 @@
+// Copyright (c) 2023-2024 Wavelet Lab
+// SPDX-License-Identifier: MIT
+
+#include <check.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "xdsp_utest_common.h"
+#include "../conv_f32_i16_2.h"
+
+#undef DEBUG_PRINT
+
+#define STREAM_SIZE (8192 + 16 + 8 + 7)
+#define STREAM_SIZE_CHECK STREAM_SIZE
+#define STREAM_SIZE_SPEED 32768
+
+#define CONV_SCALE (1.0f/32767)
+#define EPS (5E-5)
+
+static const unsigned packet_lens[3] = { 2048, 8192, STREAM_SIZE_SPEED };
+
+#define SPEED_MEASURE_ITERS 1000000
+
+static float* in = NULL;
+static int16_t* out = NULL;
+static int16_t* out_etalon = NULL;
+
+static const char* last_fn_name = NULL;
+static generic_opts_t max_opt = OPT_GENERIC;
+
+static void setup()
+{
+    posix_memalign((void**)&in,         ALIGN_BYTES, sizeof(float)   * STREAM_SIZE_SPEED);
+    posix_memalign((void**)&out,        ALIGN_BYTES, sizeof(int16_t) * STREAM_SIZE_SPEED);
+    posix_memalign((void**)&out_etalon, ALIGN_BYTES, sizeof(int16_t) * STREAM_SIZE_SPEED);
+
+    for(unsigned i = 0; i < STREAM_SIZE_SPEED; ++i)
+    {
+        in[i] = ((float)i / STREAM_SIZE_SPEED) - 0.5;
+    }
+}
+
+static void teardown()
+{
+    free(in);
+    free(out);
+    free(out_etalon);
+}
+
+static int is_equal()
+{
+    for(unsigned i = 0; i < STREAM_SIZE_CHECK; ++i)
+    {
+        float a = out[i];
+        float b = out_etalon[i];
+
+        a *= CONV_SCALE;
+        b *= CONV_SCALE;
+
+        float delta = fabs(a-b);
+        if(delta > EPS)
+        {
+            fprintf(stderr, "i = %d : in = %.6f, out = %d, etalon = %d, delta = %.6f\n", i, in[i], out[i], out_etalon[i], delta);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static conv_function_t get_fn(generic_opts_t o, int log)
+{
+    const char* fn_name = NULL;
+    conv_function_t fn = conv_get_f32_i16_c(o, &fn_name);
+
+    //ignore dups
+    if(last_fn_name && !strcmp(last_fn_name, fn_name))
+        return NULL;
+
+    if(log)
+        fprintf(stderr, "%-20s\t", fn_name);
+
+    last_fn_name = fn_name;
+    return fn;
+}
+
+START_TEST(conv_f32_i16_check)
+{
+    generic_opts_t opt = max_opt;
+    conv_function_t fn = NULL;
+    const void* pin = (const void*)in;
+          void* pout = (void*)out;
+    last_fn_name = NULL;
+
+    const size_t bzin  = STREAM_SIZE_CHECK * sizeof(float);
+    const size_t bzout = STREAM_SIZE_CHECK * sizeof(int16_t);
+
+    fprintf(stderr,"\n**** Check SIMD implementations ***\n");
+
+    //get etalon output data (generic foo)
+    (*get_fn(OPT_GENERIC, 0))(&pin, bzin, &pout, bzout);
+    memcpy(out_etalon, out, bzout);
+
+    while(opt != OPT_GENERIC)
+    {
+        conv_function_t fn = get_fn(opt--, 1);
+        if(fn)
+        {
+            memset(out, 0, bzout);
+            (*fn)(&pin, bzin, &pout, bzout);
+            int res = is_equal();
+            res ? fprintf(stderr,"\tFAILED!\n") : fprintf(stderr,"\tOK!\n");
+#ifdef DEBUG_PRINT
+            for(int i = 0; res && i < STREAM_SIZE_CHECK; ++i)
+            {
+                fprintf(stderr, "i = %d : in = %.6f, out = %d, etalon = %d\n", i, in[i], out[i], out_etalon[i]);
+            }
+#endif
+            ck_assert_int_eq( res, 0 );
+        }
+    }
+}
+END_TEST
+
+START_TEST(conv_f32_i16_speed)
+{
+    generic_opts_t opt = max_opt;
+    conv_function_t fn = NULL;
+    const void* pin = (const void*)in;
+    void* pout = (void*)out;
+    last_fn_name = NULL;
+
+    const size_t bzin  = packet_lens[_i] * sizeof(float);
+    const size_t bzout = packet_lens[_i] * sizeof(int16_t);
+
+    fprintf(stderr, "\n**** Compare SIMD implementations speed ***\n");
+    fprintf(stderr,   "**** packet: %lu bytes, iters: %u ***\n", bzin, SPEED_MEASURE_ITERS);
+
+    while(opt != OPT_GENERIC)
+    {
+        conv_function_t fn = get_fn(opt--, 1);
+        if(fn)
+        {
+            //warming
+            for(int i = 0; i < 100; ++i) (*fn)(&pin, bzin, &pout, bzout);
+
+            //measuring
+            uint64_t tk = clock_get_time();
+            for(int i = 0; i < SPEED_MEASURE_ITERS; ++i) (*fn)(&pin, bzin, &pout, bzout);
+            uint64_t tk1 = clock_get_time() - tk;
+            fprintf(stderr, "\t%" PRIu64 " us elapsed, %" PRIu64 " ns per 1 call, ave speed = %" PRIu64 " calls/s \n",
+                    tk1, (uint64_t)(tk1*1000LL/SPEED_MEASURE_ITERS), (uint64_t)(1000000LL*SPEED_MEASURE_ITERS/tk1));
+        }
+    }
+}
+END_TEST
+
+
+Suite * conv_f32_i16_suite(void)
+{
+    Suite *s;
+    TCase *tc_core;
+
+    max_opt = cpu_vcap_get();
+
+    s = suite_create("conv_f32_i16");
+    tc_core = tcase_create("XDSP");
+    tcase_set_timeout(tc_core, 60);
+    tcase_add_unchecked_fixture(tc_core, setup, teardown);
+    tcase_add_test(tc_core, conv_f32_i16_check);
+    tcase_add_loop_test(tc_core, conv_f32_i16_speed, 0, 3);
+    suite_add_tcase(s, tc_core);
+    return s;
+}

--- a/src/lib/xdsp/utests/xdsp_utest_suite.c
+++ b/src/lib/xdsp/utests/xdsp_utest_suite.c
@@ -7,6 +7,7 @@
 #include "../vbase.h"
 
 Suite * conv_i16_f32_suite(void);
+Suite * conv_f32_i16_suite(void);
 Suite * fftad_suite(void);
 Suite * rtsa_suite(void);
 Suite * fft_window_cf32_suite(void);
@@ -25,6 +26,7 @@ int main(int argc, char** argv)
     SRunner *sr;
 #if 0
     sr = srunner_create(conv_i16_f32_suite());
+    srunner_add_suite(sr, conv_f32_i16_suite());
     srunner_add_suite(sr, fftad_suite());
     srunner_add_suite(sr, rtsa_suite());
     srunner_add_suite(sr, fft_window_cf32_suite());
@@ -33,7 +35,7 @@ int main(int argc, char** argv)
     srunner_add_suite(sr, conv_f32_i12_suite());
     srunner_add_suite(sr, conv_2cf32_ci12_suite());
 #else
-    sr = srunner_create(conv_i16_f32_suite());
+    sr = srunner_create(conv_f32_i16_suite());
 #endif
     srunner_set_fork_status (sr, CK_NOFORK);
     srunner_run_all(sr, (argc > 1) ? CK_VERBOSE : CK_NORMAL);

--- a/src/lib/xdsp/utests/xdsp_utest_suite.c
+++ b/src/lib/xdsp/utests/xdsp_utest_suite.c
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
 
     int number_failed;
     SRunner *sr;
-#if 1
+#if 0
     sr = srunner_create(conv_i16_f32_suite());
     srunner_add_suite(sr, fftad_suite());
     srunner_add_suite(sr, rtsa_suite());
@@ -33,7 +33,7 @@ int main(int argc, char** argv)
     srunner_add_suite(sr, conv_f32_i12_suite());
     srunner_add_suite(sr, conv_2cf32_ci12_suite());
 #else
-    sr = srunner_create(conv_ci12_2cf32_suite());
+    sr = srunner_create(conv_i16_f32_suite());
 #endif
     srunner_set_fork_status (sr, CK_NOFORK);
     srunner_run_all(sr, (argc > 1) ? CK_VERBOSE : CK_NORMAL);


### PR DESCRIPTION
WAS
**** packet: 16384 bytes, iters: 1000000 ***
tr_conv_i16_f32_avx2		462054 us elapsed, 462 ns per 1 call, ave speed = 2164249 calls/s 
tr_conv_i16_f32_avx 		589653 us elapsed, 589 ns per 1 call, ave speed = 1695912 calls/s 
tr_conv_i16_f32_sse2		607927 us elapsed, 607 ns per 1 call, ave speed = 1644934 calls/s 
tr_conv_i16_f32_generic		2164669 us elapsed, 2164 ns per 1 call, ave speed = 461964 calls/s 

NOW
**** packet: 16384 bytes, iters: 1000000 ***
tr_conv_i16_f32_avx2		424700 us elapsed, 424 ns per 1 call, ave speed = 2354603 calls/s 
tr_conv_i16_f32_avx 		611548 us elapsed, 611 ns per 1 call, ave speed = 1635194 calls/s 
tr_conv_i16_f32_sse2		613781 us elapsed, 613 ns per 1 call, ave speed = 1629245 calls/s 
tr_conv_i16_f32_generic		2169088 us elapsed, 2169 ns per 1 call, ave speed = 461023 calls/s 

