### PR TITLE
Fix compilation error caused by cut'n'paste mistake

### DIFF
--- a/src/lib/hw/afe79xx/afe79xx.c
+++ b/src/lib/hw/afe79xx/afe79xx.c
@@ -128,7 +128,7 @@ int afe79xx_create(lldev_t dev, unsigned subdev, unsigned lsaddr, afe79xx_state_
 
     out->libcapi79xx_create = (libcapi79xx_create_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_CREATE_FN);
     out->libcapi79xx_destroy = (libcapi79xx_destroy_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_DESTROY_FN);
-    out->libcapi79xx_init = (libcapi79xx_destroy_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_INIT_FN);
+    out->libcapi79xx_init = (libcapi79xx_init_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_INIT_FN);
 
     out->libcapi79xx_upd_nco = (libcapi79xx_upd_nco_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_UPD_NCO_FN);
     out->libcapi79xx_get_nco = (libcapi79xx_get_nco_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_GET_NCO_FN);


### PR DESCRIPTION
Without this fix the build fails with the following error (gcc 14):
```
[ 22%] Building C object lib/CMakeFiles/usdr.dir/hw/afe79xx/afe79xx.c.o
/home/marcus/hack/usdr-lib/src/lib/hw/afe79xx/afe79xx.c: In function ‘afe79xx_create’:
/home/marcus/hack/usdr-lib/src/lib/hw/afe79xx/afe79xx.c:131:27: error: assignment to ‘libcapi79xx_init_fn_t’ {aka ‘int (*)(struct libcapi79xx *, const char *)’} from incompatible pointer type ‘int (*)(libcapi79xx_t *)’ {aka ‘int (*)(struct libcapi79xx *)’} [-Wincompatible-pointer-types]
  131 |     out->libcapi79xx_init = (libcapi79xx_destroy_fn_t)dlsym(out->dl_handle, LIBCAPI79XX_INIT_FN);
      |                           ^
make[2]: *** [lib/CMakeFiles/usdr.dir/build.make:524: lib/CMakeFiles/usdr.dir/hw/afe79xx/afe79xx.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:617: lib/CMakeFiles/usdr.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```