### PR TITLE
fix: correct typos in comments, logs, and frequency endpoints

### DIFF
--- a/src/lib/common/clock_gen.c
+++ b/src/lib/common/clock_gen.c
@@ -147,7 +147,7 @@ int find_best_vco(const vco_range_t* pvcos, unsigned vco_count,
         }
     }
 
-    // Freqency can't be delivered
+    // Frequency can't be delivered
     return -1;
 }
 

--- a/src/lib/device/device_cores.h
+++ b/src/lib/device/device_cores.h
@@ -32,7 +32,7 @@ enum usdr_core_subtype {
     // internal MCU glue logic
     USDR_CS_MCU = 0x7,
 
-    // Syncronization core (1PPS, Sysref, etc.)
+    // Synchronization core (1PPS, Sysref, etc.)
     USDR_CS_SYNC = 0x8,
 
     // Int bucket
@@ -109,7 +109,7 @@ enum usdr_gpi_cores {
 #define USDR_CORE_GET_ID(c)     ((c) >> 8)
 
 
-// Prdefined cores
+// Predefined cores
 #define I2C_CORE_AUTO_LUTUPD  USDR_MAKE_COREID(USDR_CS_BUS, USDR_BS_DI2C_SIMPLE)
 #define SPI_CORE_32W          USDR_MAKE_COREID(USDR_CS_BUS, USDR_BS_SPI_SIMPLE)
 #define SPI_CORE_CFGW_CS8     USDR_MAKE_COREID(USDR_CS_BUS, USDR_BS_SPI_CFG_CS8)

--- a/src/lib/device/m2_dsdr/dsdr_hiper.c
+++ b/src/lib/device/m2_dsdr/dsdr_hiper.c
@@ -272,6 +272,14 @@ static const usdr_dev_param_func_t s_fe_parameters[] = {
     { "/dm/sdr/0/smart_tune/int_mod", { dsdr_hiper_lms8001_smart_tune_int_mod_set, dsdr_hiper_lms8001_smart_tune_int_mod_get }},
     { "/dm/sdr/0/smart_tune/enabled", { dsdr_hiper_lms8001_smart_tune_enabled_set, dsdr_hiper_lms8001_smart_tune_enabled_get }},
 
+    { "/dm/sdr/0/rx/ab_l/frequency", { dsdr_hiper_lms8001_rabl_reg_set, dsdr_hiper_lms8001_rabl_reg_get }},
+    { "/dm/sdr/0/rx/cd_l/frequency", { dsdr_hiper_lms8001_rcdl_reg_set, dsdr_hiper_lms8001_rcdl_reg_get }},
+    { "/dm/sdr/0/rx/ab_h/frequency", { dsdr_hiper_lms8001_rabh_reg_set, dsdr_hiper_lms8001_rabh_reg_get }},
+    { "/dm/sdr/0/rx/cd_h/frequency", { dsdr_hiper_lms8001_rcdh_reg_set, dsdr_hiper_lms8001_rcdh_reg_get }},
+    { "/dm/sdr/0/tx/ab/frequency", { dsdr_hiper_lms8001_tab_reg_set, dsdr_hiper_lms8001_tab_reg_get }},
+    { "/dm/sdr/0/tx/cd/frequency", { dsdr_hiper_lms8001_tcd_reg_set, dsdr_hiper_lms8001_tcd_reg_get }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/ab_l/freqency", { dsdr_hiper_lms8001_rabl_reg_set, dsdr_hiper_lms8001_rabl_reg_get }},
     { "/dm/sdr/0/rx/cd_l/freqency", { dsdr_hiper_lms8001_rcdl_reg_set, dsdr_hiper_lms8001_rcdl_reg_get }},
     { "/dm/sdr/0/rx/ab_h/freqency", { dsdr_hiper_lms8001_rabh_reg_set, dsdr_hiper_lms8001_rabh_reg_get }},

--- a/src/lib/device/m2_dsdr/m2_dsdr.c
+++ b/src/lib/device/m2_dsdr/m2_dsdr.c
@@ -410,6 +410,17 @@ const usdr_dev_param_func_t s_fparams_m2_dsdr_rev000[] = {
     { "/dm/sdr/0/tx/gain/6",      { dev_m2_dsdr_gain_tx_set, NULL }},
     { "/dm/sdr/0/tx/gain/7",      { dev_m2_dsdr_gain_tx_set, NULL }},
 
+    { "/dm/sdr/0/rx/frequency",    { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/0",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/1",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/2",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/3",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/4",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/5",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/6",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/rx/frequency/7",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency",    { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
     { "/dm/sdr/0/rx/freqency/0",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
     { "/dm/sdr/0/rx/freqency/1",  { dev_m2_dsdr_sdr_rx_freq_set, NULL }},
@@ -430,6 +441,17 @@ const usdr_dev_param_func_t s_fparams_m2_dsdr_rev000[] = {
     { "/dm/sdr/0/rx/dsa/6",       { dev_m2_dsdr_sdr_rx_dsa_set, NULL }},
     { "/dm/sdr/0/rx/dsa/7",       { dev_m2_dsdr_sdr_rx_dsa_set, NULL }},
 
+    { "/dm/sdr/0/tx/frequency",    { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/0",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/1",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/2",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/3",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/4",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/5",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/6",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/7",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/tx/freqency",    { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
     { "/dm/sdr/0/tx/freqency/0",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
     { "/dm/sdr/0/tx/freqency/1",  { dev_m2_dsdr_sdr_tx_freq_set, NULL }},
@@ -1248,7 +1270,7 @@ int dev_m2_dsdr_sdr_rx_freq_set(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t valu
         return 0;
 
     if (obj->full_path[0])
-        return dsdr_iterate_ordinal_chans(ud, obj, value, "/dm/sdr/0/rx/freqency", true);
+        return dsdr_iterate_ordinal_chans(ud, obj, value, "/dm/sdr/0/rx/frequency", true);
 
     return dsdr_set_rx_frequency_chan(d, value, obj->full_path[1]);
 }
@@ -1297,7 +1319,7 @@ int dev_m2_dsdr_sdr_tx_freq_set(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t valu
         return 0;
 
     if (obj->full_path[0])
-        return dsdr_iterate_ordinal_chans(ud, obj, value, "/dm/sdr/0/tx/freqency", false);
+        return dsdr_iterate_ordinal_chans(ud, obj, value, "/dm/sdr/0/tx/frequency", false);
 
     return dsdr_set_tx_frequency_chan(d, value, obj->full_path[1]);
 }

--- a/src/lib/device/m2_lm6_1/m2_lm6_1.c
+++ b/src/lib/device/m2_lm6_1/m2_lm6_1.c
@@ -232,9 +232,15 @@ const usdr_dev_param_func_t s_fparams_m2_lm6_1_rev000[] = {
 
     { "/dm/sdr/0/calibrate",    { dev_m2_lm6_1_sdr_dc_calib, NULL }},
 
+    { "/dm/sdr/0/rx/frequency/lob",{ dev_m2_lm6_1_sdr_rx_freq_lob_set, NULL }},
+    { "/dm/sdr/0/rx/frequency",  { dev_m2_lm6_1_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency",  { dev_m2_lm6_1_sdr_tx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency/lob",{ dev_m2_lm6_1_sdr_rx_freq_lob_set, NULL }},
     { "/dm/sdr/0/rx/freqency",  { dev_m2_lm6_1_sdr_rx_freq_set, NULL }},
     { "/dm/sdr/0/tx/freqency",  { dev_m2_lm6_1_sdr_tx_freq_set, NULL }},
+
     { "/dm/sdr/0/rx/gain",      { dev_m2_lm6_1_sdr_rx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain",      { dev_m2_lm6_1_sdr_tx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain/vga1", { dev_m2_lm6_1_sdr_tx_gain_vga1_set, NULL }},

--- a/src/lib/device/m2_lm7_1/m2_lm7_1.c
+++ b/src/lib/device/m2_lm7_1/m2_lm7_1.c
@@ -297,11 +297,20 @@ const usdr_dev_param_func_t s_fparams_m2_lm7_1_rev000[] = {
     { "/dm/sdr/0/rx/phgaincorr",{ dev_m2_lm7_1_sdr_rx_phgaincorr_set, NULL }},
     { "/dm/sdr/0/tx/phgaincorr",{ dev_m2_lm7_1_sdr_tx_phgaincorr_set, NULL }},
 
+    { "/dm/sdr/0/rx/frequency/bb",  { dev_m2_lm7_1_sdr_rx_bbfreq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency/bb",  { dev_m2_lm7_1_sdr_tx_bbfreq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency/bb",  { dev_m2_lm7_1_sdr_rx_bbfreq_set, NULL }},
     { "/dm/sdr/0/tx/freqency/bb",  { dev_m2_lm7_1_sdr_tx_bbfreq_set, NULL }},
 
+    { "/dm/sdr/0/rx/frequency",  { dev_m2_lm7_1_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency",  { dev_m2_lm7_1_sdr_tx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency",  { dev_m2_lm7_1_sdr_rx_freq_set, NULL }},
     { "/dm/sdr/0/tx/freqency",  { dev_m2_lm7_1_sdr_tx_freq_set, NULL }},
+
     { "/dm/sdr/0/rx/gain",      { dev_m2_lm7_1_sdr_rx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain",      { dev_m2_lm7_1_sdr_tx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain/lb",   { dev_m2_lm7_1_sdr_tx_gainlb_set, NULL }},
@@ -325,19 +334,32 @@ const usdr_dev_param_func_t s_fparams_m2_lm7_1_rev000[] = {
 
     { "/dm/sdr/0/rxdsp/swapab", { dev_m2_lm7_1_sdr_rxdsp_swapab_set, NULL }},
 
+    { "/dm/sdr/0/tdd/frequency",          { dev_m2_lm7_1_sdr_tdd_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/tdd/freqency",          { dev_m2_lm7_1_sdr_tdd_freq_set, NULL }},
+
     { "/dm/sdr/0/tfe/antcfg",            { dev_m2_lm7_1_tx_antennat_port_cfg_set, NULL }},
 
     { "/dm/sdr/0/tfe/generator/enable",  { dev_m2_lm7_1_tfe_gen_en_set, NULL }},
     { "/dm/sdr/0/tfe/generator/const",   { dev_m2_lm7_1_tfe_gen_const_set, NULL }},
     { "/dm/sdr/0/tfe/generator/tone",    { dev_m2_lm7_1_tfe_gen_tone_set, NULL }},
     { "/dm/sdr/0/tfe/nco/enable",        { dev_m2_lm7_1_tfe_nco_enable_set, NULL }},
+
+    { "/dm/sdr/0/tfe/nco/frequency",      { dev_m2_lm7_1_tfe_nco_enable_frequency, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/tfe/nco/freqency",      { dev_m2_lm7_1_tfe_nco_enable_frequency, NULL }},
 
     { "/dm/sdr/0/rfe/throttle",    { dev_m2_lm7_1_rfe_throttle_set, NULL }},
 
     { "/dm/sdr/0/rfe/nco/enable",  { dev_m2_lm7_1_rfe_nco_enable_set, NULL }},
+
+    { "/dm/sdr/0/rfe/nco/frequency",{ dev_m2_lm7_1_rfe_nco_enable_frequency, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rfe/nco/freqency",{ dev_m2_lm7_1_rfe_nco_enable_frequency, NULL }},
+
     { "/dm/sdr/0/rfe/pwrdc",       { NULL, dev_m2_lm7_1_rfe_nco_pwrdc_get }},
 
     // Debug interface

--- a/src/lib/device/m2_lsdr/m2_da09_4_ad45_2.c
+++ b/src/lib/device/m2_lsdr/m2_da09_4_ad45_2.c
@@ -180,7 +180,11 @@ const usdr_dev_param_func_t s_fparams_m2_da09_4_ad45_2_rev000[] = {
     { "/dm/sdr/0/rx/gain/vga",  { dev_m2_d09_4_ad45_2_gainvga_set, NULL }},
     { "/dm/sdr/0/rx/gain/lna",  { dev_m2_d09_4_ad45_2_gainlna_set, NULL }},
 
+    { "/dm/sdr/0/rx/frequency",  { dev_m2_d09_4_ad45_2_sdr_rx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency",  { dev_m2_d09_4_ad45_2_sdr_rx_freq_set, NULL }},
+
     { "/dm/sdr/0/rx/bandwidth", { dev_m2_d09_4_ad45_2_sdr_rx_bandwidth_set, NULL }},
 
     { "/dm/sdr/0/rx/path",      { dev_m2_d09_4_ad45_2_dummy, NULL }},

--- a/src/lib/device/u3_limesdr/u3_limesdr.c
+++ b/src/lib/device/u3_limesdr/u3_limesdr.c
@@ -91,8 +91,13 @@ const usdr_dev_param_func_t s_fparams_u3_limesdr_0[] = {
     { "/dm/sdr/refclk/path",    { dev_limesdr_refclk_path_set, NULL }},
     { "/dm/power/en",           { dev_limesdr_pwren_set, NULL }},
 
+    { "/dm/sdr/0/rx/frequency",  { dev_limesdr_sdr_rx_freq_set, NULL }},
+    { "/dm/sdr/0/tx/frequency",  { dev_limesdr_sdr_tx_freq_set, NULL }},
+
+    /* TODO: delete block below after several releases, these are just aliases to above due typo for compatibility with old code */
     { "/dm/sdr/0/rx/freqency",  { dev_limesdr_sdr_rx_freq_set, NULL }},
     { "/dm/sdr/0/tx/freqency",  { dev_limesdr_sdr_tx_freq_set, NULL }},
+
     { "/dm/sdr/0/rx/gain",      { dev_limesdr_sdr_rx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain",      { dev_limesdr_sdr_tx_gain_set, NULL }},
     { "/dm/sdr/0/tx/gain/lb",   { dev_limesdr_sdr_tx_gainlb_set, NULL }},

--- a/src/lib/hw/lmk04832/lmk04832.c
+++ b/src/lib/hw/lmk04832/lmk04832.c
@@ -335,7 +335,7 @@ pll2_configured:;
         MAKE_LMK04832_PLL2_N_LOW(pll2_n),
         0x016959, //PLL2_DLD_EN
 
-        //SYSREF enable in continous from data clock
+        //SYSREF enable in continuous from data clock
         //0x013903,
         //0x013a00,
         //0x013b08,
@@ -432,7 +432,7 @@ int lmk04832_sysref_div_set(lldev_t dev, subdev_t subdev, lsopaddr_t addr,
         0x014310,
         0x0144ff,
 
-        //SYSREF enable in continous from data clock
+        //SYSREF enable in continuous from data clock
         0x013903,
 
         //DDIV

--- a/src/lib/hw/lms8001/lms8001.c
+++ b/src/lib/hw/lms8001/lms8001.c
@@ -1146,7 +1146,7 @@ int lms8001_smart_tune(lms8001_state_t* m, unsigned tune_flags, uint64_t flo, in
 
 int lms8001_reg_set(lms8001_state_t* m, uint16_t addr, uint16_t val)
 {
-    // Update internal state to syncronze cahce values
+    // Update internal state to synchronize cache values
 
     if (addr >= PLL_CONFIGURATION_PLL_VREG) {
         switch (addr) {

--- a/src/lib/ipblks/lms64c_proto.c
+++ b/src/lib/ipblks/lms64c_proto.c
@@ -114,7 +114,7 @@ int lms64c_fill_packet(uint8_t cmd, uint8_t status, uint8_t id, const uint8_t* d
         } else if (mod == MOD_INT16) {
             const uint16_t* d = (const uint16_t*)&data[off];
             for (unsigned i = 0; i < this_pkt_data; i += 2) {
-                // TODO: Endianess
+                // TODO: Endianness
                 out[k].data[i + 0] = d[i >> 1] >> 8;
                 out[k].data[i + 1] = d[i >> 1] & 0xFF;
             }
@@ -140,7 +140,7 @@ int lms64c_parse_packet(uint8_t cmd, const proto_lms64c_t* in, unsigned in_cnt, 
         unsigned bsz = (remaining > LMS64C_DATA_LENGTH) ? LMS64C_DATA_LENGTH : remaining;
 
         if (mod == MOD_INT32_16) {
-            // TODO: Endianess
+            // TODO: Endianness
             const uint16_t* d = (const uint16_t*)in[i].data;
             for (unsigned j = 0; j < bsz; j += 2) {
                 data[off + j + 0] = d[j + 1] >> 8;

--- a/src/lib/ipblks/streams/stream_limesdr.c
+++ b/src/lib/ipblks/streams/stream_limesdr.c
@@ -47,7 +47,7 @@ struct stream_limesdr {
     // Streaming parameters
     unsigned burst_count; // Bursts in packet
     unsigned burst_symbs;
-    unsigned burst_bytes;     // Busrt bytes contating samples
+    unsigned burst_bytes;     // Burst bytes containing samples
     unsigned burst_host_bytes;
     unsigned block_samples; // Number samples in one process block (4K)
     unsigned tx_sampl_c;

--- a/src/lib/ipblks/streams/stream_sfetrx4_dma32.c
+++ b/src/lib/ipblks/streams/stream_sfetrx4_dma32.c
@@ -57,7 +57,7 @@ struct stream_sfetrx_dma32 {
     // Cached values
     unsigned cnf_base;
     unsigned sync_base;  // TODO: for compatibility with OLD APIs
-    unsigned cnfrd_base; // Reabdack address for OLD API
+    unsigned cnfrd_base; // Readback address for OLD API
 
     unsigned pkt_symbs;  // Total number of symbols in a transaction (all bursts)
     unsigned pkt_bytes;  // Wire bytes for a transaction (excl. packing overhead)
@@ -81,7 +81,7 @@ struct stream_sfetrx_dma32 {
     uint8_t  fe_old_tx_mute; // keep OLD TX FE in sync with host state
     uint8_t  fe_old_tx_swap; // keep OLD TX FE in sync with host state
     unsigned fe_chans;       // Number of active channels in frontend
-    unsigned fe_complex;     // Compex data streaming
+    unsigned fe_complex;     // Complex data streaming
     union {
         sfe_cfg_t srx4;
     } storage;
@@ -108,7 +108,7 @@ int _sfetrx4_destroy(stream_handle_t* str)
     int res;
 
     if (stream->type == USDR_ZCPY_RX) {
-        //Grcefull stop
+        //Gracefull stop
         res = lowlevel_reg_wr32(dev, 0,
                                 stream->cnf_base + 1, 0);
         if (res)
@@ -296,7 +296,7 @@ void parse_txcore_stat(uint32_t stat[4], txcore_statistics_t* s)
     // Understanding counters (PCIe mode)
     // usrbuf_posted     --     PCIe Buffer metadata posted
     // usrbuf_requested  --     PCIe Buffer all MemRd requests are sent
-    // usrbuf_completed  --     PCIe Beffer data has been placed into FIFO RAM
+    // usrbuf_completed  --     PCIe Buffer data has been placed into FIFO RAM
     // usrbuf_aired      --     PCIe Buffer has been completly played out (available for reuse)
 
     bool usb = (stat[0] & 0x8);
@@ -529,7 +529,7 @@ static int _sfetrx4_op(stream_handle_t* str,
         if (res)
             return res;
     } else {
-        // Assuming Compex IQ
+        // Assuming Complex IQ
         unsigned lgchcnt = (stream->fe_chans == 1) ? 0 :
                            (stream->fe_chans == 2) ? 1 :
                            (stream->fe_chans == 4) ? 2 : 3;
@@ -1275,7 +1275,7 @@ int sfetrx4_stream_sync(device_t* device,
     stream_sfetrx_dma32_t** pstream = (stream_sfetrx_dma32_t**)pstr;
     res = usdr_device_vfs_obj_val_get_u64(device, "/ll/sync/0/base", &sync_base);
     if (res) {
-        USDR_LL_LOG(device->dev, "DSTR", USDR_LOG_ERROR, "SYNC: Broken device! Coulnd't obtain sync addr: %d\n", res);
+        USDR_LL_LOG(device->dev, "DSTR", USDR_LOG_ERROR, "SYNC: Broken device! Couldn't obtain sync addr: %d\n", res);
         return res;
     }
     retimer_base = sync_base;

--- a/src/lib/ipblks/streams/stream_sfetrx4_dma32.h
+++ b/src/lib/ipblks/streams/stream_sfetrx4_dma32.h
@@ -56,7 +56,7 @@ int create_sfetrx4_stream(device_t* device,
                           stream_handle_t** outu,
                           unsigned *hw_chans_cnt);
 
-// Syncronize streams
+// Synchronize streams
 int sfetrx4_stream_sync(device_t* device,
                         stream_handle_t** pstream, unsigned scount,
                         const char* synctype);

--- a/src/lib/ipblks/xlnx_bitstream.c
+++ b/src/lib/ipblks/xlnx_bitstream.c
@@ -179,7 +179,7 @@ next:
             }
 
             if (count == 1 && ptype == 1 && reg != 1 && reg != XLNX_REG_CMD) {
-                USDR_LOG("BSTR", USDR_LOG_NOTE, "Rgister %x: %x\n", reg, w);
+                USDR_LOG("BSTR", USDR_LOG_NOTE, "Register %x: %x\n", reg, w);
             }
 
             if (flags & XLNX_BSTRM_PARSE_F_CRC_CHECK) {

--- a/src/lib/json_controller/controller.c
+++ b/src/lib/json_controller/controller.c
@@ -356,7 +356,7 @@ int generic_rpc_call(pdm_dev_t dmdev,
         uint64_t actual;
 
         res = set_endpoint_uint_param(dmdev,
-                                      (pcall->call_type == SDR_RX_FREQUENCY) ? "/dm/sdr/0/rx/freqency" : "/dm/sdr/0/tx/freqency",
+                                      (pcall->call_type == SDR_RX_FREQUENCY) ? "/dm/sdr/0/rx/frequency" : "/dm/sdr/0/tx/frequency",
                                       freq,
                                       &actual);
         if (res)

--- a/src/lib/lowlevel/libusb_generic.c
+++ b/src/lib/lowlevel/libusb_generic.c
@@ -601,7 +601,7 @@ void LIBUSB_CALL libusb_transfer_buffers_cb(struct libusb_transfer *transfer)
              idx, transfer->status, transfer->actual_length, transfer->length);
 
     if (rxb->stop) {
-        // TODO: Syncronize EPs
+        // TODO: Synchronize EPs
         return;
     }
 

--- a/src/lib/lowlevel/pcie_uram/pcie_uram_main.c
+++ b/src/lib/lowlevel/pcie_uram/pcie_uram_main.c
@@ -595,7 +595,7 @@ int pcie_uram_dma_wait_or_alloc(struct pcie_uram_dev* d, bool rx, stream_t chann
         }
 
         sc->bufavail = res;
-        USDR_LL_LOG(&d->ll, "PCIE", (res > 1) ? USDR_LOG_NOTE : USDR_LOG_DEBUG, "STR[%d]: Alloced %d buffs, BNO=%d (%016lx) seq=%16ld OOB_sz=%d\n",
+        USDR_LL_LOG(&d->ll, "PCIE", (res > 1) ? USDR_LOG_NOTE : USDR_LOG_DEBUG, "STR[%d]: Allocated %d buffs, BNO=%d (%016lx) seq=%16ld OOB_sz=%d\n",
                  channel, res, sc->bno, (oob_ptr) ? (*(uint64_t*)sc->oob_cache) : 0, sc->seq, sc->oob_size);
     }
 
@@ -951,9 +951,9 @@ int pcie_uram_plugin_create(unsigned pcount, const char** devparam, const char**
     err = usdr_device_create(&dev->ll, did);
     if (err) {
         USDR_LL_LOG(&dev->ll, "PCIE", USDR_LOG_ERROR,
-                 "Unable to find device spcec for %s, uuid %s! Update software!\n",
-                 dev->name,
-                 usdr_device_id_to_str(did));
+             "Unable to find device spec for %s, uuid %s! Update software!\n",
+             dev->name,
+             usdr_device_id_to_str(did));
 
         goto remove_dev;
     }

--- a/src/lib/lowlevel/usb_ft601/usb_ft601_generic.c
+++ b/src/lib/lowlevel/usb_ft601/usb_ft601_generic.c
@@ -100,7 +100,7 @@ int usbft601_uram_ls_op(lldev_t dev, subdev_t subdev,
             if (memoutsz * 2 > sizeof(tmpbuf_out))
                 return -E2BIG;
 
-            // Rgister write
+            // Register write
             const uint16_t* out_s = (const uint16_t* )pout;
             for (unsigned i = 0; i < memoutsz / 2; i++) {
                 tmpbuf_out[2 * i + 1] = ls_op_addr + i;
@@ -200,8 +200,8 @@ int usbft601_uram_generic_create_and_init(lldev_t lld, unsigned pcount, const ch
     res = usdr_device_create(lld, *pdevid);
     if (res) {
         USDR_LOG(USBG_LOG_TAG, USDR_LOG_ERROR,
-                 "Unable to find device spcec for %s, uuid %s! Update software!\n",
-                 devname, usdr_device_id_to_str(*pdevid));
+             "Unable to find device spec for %s, uuid %s! Update software!\n",
+             devname, usdr_device_id_to_str(*pdevid));
 
         return res;
     }

--- a/src/lib/lowlevel/usb_ft601/usb_ft601_libusb.c
+++ b/src/lib/lowlevel/usb_ft601/usb_ft601_libusb.c
@@ -325,7 +325,7 @@ int usbft601_uram_send_dma_commit(lldev_t dev, subdev_t subdev, stream_t channel
     // Add to senq
     res = buffers_usb_transfer_post(rxb, bno, sz, bno);
     if (res) {
-        USDR_LOG("USBX", USDR_LOG_ERROR,"USB TX%d unable to post busrt to sendq (error %d)\n", channel, res);
+        USDR_LOG("USBX", USDR_LOG_ERROR,"USB TX%d unable to post burst to sendq (error %d)\n", channel, res);
         return res;
     }
 

--- a/src/lib/lowlevel/usb_uram/usb_uram_generic.c
+++ b/src/lib/lowlevel/usb_uram/usb_uram_generic.c
@@ -301,8 +301,8 @@ int usb_uram_generic_create_and_init(lldev_t dev, unsigned pcount, const char** 
     res = usdr_device_create(dev, *pdevid);
     if (res) {
         USDR_LOG(USBG_LOG_TAG, USDR_LOG_ERROR,
-                 "Unable to find device spcec for %s, uuid %s! Update software!\n",
-                 devname, usdr_device_id_to_str(*pdevid));
+             "Unable to find device spec for %s, uuid %s! Update software!\n",
+             devname, usdr_device_id_to_str(*pdevid));
 
         return res;
     }

--- a/src/lib/lowlevel/usb_uram/usb_uram_libusb.c
+++ b/src/lib/lowlevel/usb_uram/usb_uram_libusb.c
@@ -777,7 +777,7 @@ int usb_uram_send_dma_commit(lldev_t dev, subdev_t subdev, stream_t channel, voi
     // Add to senq
     res = buffers_usb_transfer_post(rxb, bno, sz + 16, bno);
     if (res) {
-        USDR_LOG("USBX", USDR_LOG_ERROR,"USB TX%d unable to post busrt to sendq (error %d)\n", channel, res);
+        USDR_LOG("USBX", USDR_LOG_ERROR,"USB TX%d unable to post burst to sendq (error %d)\n", channel, res);
         return res;
     }
     return 0;

--- a/src/lib/lowlevel/verilator_ll/verilatorll_wrap.c
+++ b/src/lib/lowlevel/verilator_ll/verilatorll_wrap.c
@@ -923,8 +923,8 @@ int verilator_wrap_plugin_create(unsigned pcount, const char** devparam,
     res = usdr_device_create(dev, did, &dev->udev);
     if (res) {
         USDR_LOG("VERI", USDR_LOG_ERROR,
-                 "Unable to find device spcec for %s, uuid %s! Update software!\n",
-                 dev->name, usdr_device_id_to_str(did));
+             "Unable to find device spec for %s, uuid %s! Update software!\n",
+             dev->name, usdr_device_id_to_str(did));
 
         goto remove_dev;
     }

--- a/src/lib/lowlevel/verilator_ll/verilatorll_wrap.h
+++ b/src/lib/lowlevel/verilator_ll/verilatorll_wrap.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-2024 Wavelet Lab
 // SPDX-License-Identifier: MIT
 
-// Communiction protocol
+// Communication protocol
 
 #include <stdint.h>
 

--- a/src/lib/lowlevel/verilator_ll/vpu.h
+++ b/src/lib/lowlevel/verilator_ll/vpu.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-2024 Wavelet Lab
 // SPDX-License-Identifier: MIT
 
-// Communiction protocol
+// Communication protocol
 #ifndef VPU_H
 #define VPU_H
 

--- a/src/lib/xdsp/sincos_functions.h
+++ b/src/lib/xdsp/sincos_functions.h
@@ -32,7 +32,7 @@ sincos_i16_interleaved_ctrl_function_t get_wvlt_sincos_i16_interleaved_ctrl();
  * wvlt_sincos_i16_interleaved_ctrl()
  *
  * int32_t* start_phase: Starting phase.
- *                       Diapazon [-PI..+PI) mapped to int32 range INT32_MIN..INT32_MAX.
+ *                       Range [-PI..+PI) mapped to int32 range INT32_MIN..INT32_MAX.
  *                       The next starting phase for consequent calls is returned by ptr.
  * int32_t delta_phase:  Delta, applying to starting phase. int32_t range is just the same as for start_phase.
  * int16_t gain:         Output max amplitude

--- a/src/soapysdr/usdr_soapy.cpp
+++ b/src/soapysdr/usdr_soapy.cpp
@@ -593,7 +593,7 @@ void SoapyUSDR::setFrequency(const int direction, const size_t channel, const st
     int res;
 
     const char* dir = (direction == SOAPY_SDR_TX) ? "tx" : "rx";
-    const char* pname = get_sdr_param(0, dir, "freqency", (name == "BB") ? "bb" : NULL);
+    const char* pname = get_sdr_param(0, dir, "frequency", (name == "BB") ? "bb" : NULL);
 
     uint64_t val = (((uint64_t)channel) << 32) | (uint32_t)frequency;
 

--- a/src/tests/lms7_cal.c
+++ b/src/tests/lms7_cal.c
@@ -162,14 +162,14 @@ int dev_initialize(const char* devstring, unsigned spb, unsigned loglevel, float
 
     fprintf(stderr, "Configured %d x %d buffs\n", blksz, bufcnt);
 
-    res = usdr_dme_set_uint(dev, usdr_dmd_find_entity(dev, "/dm/sdr/0/rx/freqency"), freq);
+    res = usdr_dme_set_uint(dev, usdr_dmd_find_entity(dev, "/dm/sdr/0/rx/frequency"), freq);
     if (res) {
         fprintf(stderr, "Unable to set rx frequency: errno %d\n", res);
         goto dev_close;
     }
 
     if (freq_tx > 0) {
-        res = usdr_dme_set_uint(dev, usdr_dmd_find_entity(dev, "/dm/sdr/0/tx/freqency"), freq_tx);
+        res = usdr_dme_set_uint(dev, usdr_dmd_find_entity(dev, "/dm/sdr/0/tx/frequency"), freq_tx);
         if (res) {
             fprintf(stderr, "Unable to set tx frequency: errno %d\n", res);
             goto dev_close;

--- a/src/tests/lowlevel_lvds_perf.c
+++ b/src/tests/lowlevel_lvds_perf.c
@@ -479,7 +479,7 @@ int main(int argc, char** argv)
     usdrlog_setlevel(NULL, USDR_LOG_TRACE);
     usdrlog_enablecolorize(NULL);
     unsigned iten = 100; // Iterate over smaplerate
-    unsigned cont = 0; // Continous test
+    unsigned cont = 0; // Continuous test
     unsigned longtest = 0;
     unsigned loglevel = 2;
     unsigned verbosity = 1;

--- a/src/tests/simpleapi.c
+++ b/src/tests/simpleapi.c
@@ -54,7 +54,7 @@ void Initialize(const char* device_string, int loglevel,
     CheckErrorAndDie(res, "rx info");
 
     res = usdr_dms_sync(pdev->dev, "off", 2, pdev->strms);
-    CheckErrorAndDie(res, "tx & rx syncronization off");
+    CheckErrorAndDie(res, "tx & rx synchronization off");
 
     res = usdr_dms_op(pdev->strms[0], USDR_DMS_START, 0);
     CheckErrorAndDie(res, "rx stream precharge");
@@ -179,14 +179,14 @@ void SetRxPgaGain(sdr_data_t* pdev, int gain)
 void SetTxFreq(sdr_data_t* pdev, unsigned freq)
 {
     int res;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/freqency",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/frequency",
                             freq);
     CheckErrorAndDie(res, "SetTxFreq");
 }
 void SetRxFreq(sdr_data_t* pdev, unsigned freq)
 {
     int res;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/freqency",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/frequency",
                             freq);
     CheckErrorAndDie(res, "SetRxFreq");
 }
@@ -195,7 +195,7 @@ void SetBBTxFreq(sdr_data_t* pdev, int chan, int freq)
 {
     int res;
     uint64_t val = (((uint64_t)chan) << 32) | (uint32_t)freq;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/freqency/bb",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/frequency/bb",
                             val);
     CheckErrorAndDie(res, "SetBBTxFreq");
 }
@@ -203,7 +203,7 @@ void SetBBRxFreq(sdr_data_t* pdev, int chan, int freq)
 {
     int res;
     uint64_t val = (((uint64_t)chan) << 32) | (uint32_t)freq;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/freqency/bb",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/frequency/bb",
                             val);
     CheckErrorAndDie(res, "SetBBRxFreq");
 }

--- a/src/tests/usdr_simple_api_test.c
+++ b/src/tests/usdr_simple_api_test.c
@@ -120,7 +120,7 @@ void Initialize(const char* device_string, int loglevel,
     CheckErrorAndDie(res, "rx info");
 
     res = usdr_dms_sync(pdev->dev, "off", 2, pdev->strms);
-    CheckErrorAndDie(res, "tx & rx syncronization off");
+    CheckErrorAndDie(res, "tx & rx synchronization off");
 
     res = usdr_dms_op(pdev->strms[0], USDR_DMS_START, 0);
     CheckErrorAndDie(res, "rx stream precharge");
@@ -235,14 +235,14 @@ void SetRxPgaGain(sdr_data_t* pdev, int gain)
 void SetTxFreq(sdr_data_t* pdev, unsigned freq)
 {
     int res;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/freqency",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/frequency",
                             freq);
     CheckErrorAndDie(res, "SetTxFreq");
 }
 void SetRxFreq(sdr_data_t* pdev, unsigned freq)
 {
     int res;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/freqency",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/frequency",
                             freq);
     CheckErrorAndDie(res, "SetRxFreq");
 }
@@ -251,7 +251,7 @@ void SetBBTxFreq(sdr_data_t* pdev, int chan, int freq)
 {
     int res;
     uint64_t val = (((uint64_t)chan) << 32) | (uint32_t)freq;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/freqency/bb",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/tx/frequency/bb",
                             val);
     CheckErrorAndDie(res, "SetBBTxFreq");
 }
@@ -259,7 +259,7 @@ void SetBBRxFreq(sdr_data_t* pdev, int chan, int freq)
 {
     int res;
     uint64_t val = (((uint64_t)chan) << 32) | (uint32_t)freq;
-    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/freqency/bb",
+    res = usdr_dme_set_uint(pdev->dev, "/dm/sdr/0/rx/frequency/bb",
                             val);
     CheckErrorAndDie(res, "SetBBRxFreq");
 }
@@ -378,7 +378,7 @@ int main(int argc, char** argv)
     SetTxBandwidth(&data, tx_bandwidth);
     SetRxBandwidth(&data, rx_bandwidth);
 
-    // Optionall tune frequency offset
+    // Optionally tune frequency offset
     // TrimDacVCTCXO(&data, 43981);
 
     // Do calibration only when All gains / freqs are set but before actual start

--- a/src/tools/usdr_dm_create.c
+++ b/src/tools/usdr_dm_create.c
@@ -657,10 +657,10 @@ int main(UNUSED int argc, UNUSED char** argv)
     //Device parameters
     //                 { endpoint, default_value, ignore flag, stop_on_fail flag }
     struct dme_findsetv_data dev_data[] = {
-        [DD_RX_FREQ] = { "rx/freqency", 900e6, true, true },
-        [DD_TX_FREQ] = { "tx/freqency", 920e6, true, true },
+        [DD_RX_FREQ] = { "rx/frequency", 900e6, true, true },
+        [DD_TX_FREQ] = { "tx/frequency", 920e6, true, true },
 
-        [DD_TDD_FREQ] = { "tdd/freqency", 910e6, true, true },
+        [DD_TDD_FREQ] = { "tdd/frequency", 910e6, true, true },
 
         [DD_RX_BANDWIDTH] = { "rx/bandwidth", 1e6, true, true },
         [DD_TX_BANDWIDTH] = { "tx/bandwidth", 1e6, true, true },


### PR DESCRIPTION
- Fix multiple spelling errors in comments and log messages
- Rename incorrect SDR parameter paths from */freqency to */frequency (old paths are kept for several releases for backward compatibility)
- Improve wording consistency in low-level and stream modules
- Minor formatting alignment in log messages