### PR TITLE
usb_uram: fix SPI array out-of-bounds indexing

### DIFF
--- a/src/lib/lowlevel/usb_uram/usb_uram_generic.c
+++ b/src/lib/lowlevel/usb_uram/usb_uram_generic.c
@@ -166,13 +166,13 @@ int usb_uram_ls_op(lldev_t dev, subdev_t subdev,
         if (SPIEXT_LSOP_GET_BUS(ls_op_addr) >= pdb->spi_count)
             return -EINVAL;
 
-        if (pdb->spi_core[ls_op_addr] == SPI_CORE_32W) {
+        if (pdb->spi_core[SPIEXT_LSOP_GET_BUS(ls_op_addr)] == SPI_CORE_32W) {
             if (((meminsz != 4) && (meminsz != 0)) || (memoutsz != 4))
                 return -EINVAL;
 
             res = usb_uram_reg_out(dev, pdb->spi_base[SPIEXT_LSOP_GET_BUS(ls_op_addr)],
                                    *(const uint32_t*)pout);
-        } else if (pdb->spi_core[ls_op_addr] == SPI_CORE_CFGW_CS8) {
+        } else if (pdb->spi_core[SPIEXT_LSOP_GET_BUS(ls_op_addr)] == SPI_CORE_CFGW_CS8) {
             uint32_t spi_tr[2] = {
                 SPIEXT_LSOP_GET_CFG(ls_op_addr),
                 spiext_make_data_reg(memoutsz, pout)
@@ -265,8 +265,8 @@ int usb_uram_read_wait(lldev_t dev, unsigned lsop, lsopaddr_t ls_op_addr, size_t
     switch(lsop)
     {
     case USDR_LSOP_SPI:
-        int_number = gen->spi_int_number[ls_op_addr];
-        reg = gen->db.spi_core[ls_op_addr];
+        int_number = gen->spi_int_number[SPIEXT_LSOP_GET_BUS(ls_op_addr)];
+        reg = gen->db.spi_core[SPIEXT_LSOP_GET_BUS(ls_op_addr)];
         strcpy(busname, "SPI");
         break;
     case USDR_LSOP_I2C_DEV:


### PR DESCRIPTION
## Summary

In `usb_uram_generic.c`, `spi_core[]` (8 elements) and `spi_int_number[]`
are indexed with raw `ls_op_addr` instead of `SPIEXT_LSOP_GET_BUS(ls_op_addr)`.
Since `ls_op_addr` encodes `(cfg << 16) | (eaddr << 8) | bus`, SPI transactions
with non-zero config or extended address fields can index these arrays out of
bounds.

The PCIe implementation (`pcie_uram_main.c`) correctly uses the extraction
macro throughout; this patch aligns the USB path. When `ls_op_addr` encodes
only a bus value in the low bits, behavior is unchanged; this patch only
corrects array indexing for packed addresses with non-zero higher fields.

Note: in `usb_uram_read_wait`, the `reg` parameter is `UNUSED` in the
current `usb_read_bus` implementation. I kept the existing `spi_core` field
rather than changing to `spi_base` to keep the diff minimal, but this may
warrant a follow-up if `io_read_bus_fn` implementations that use `reg` are
added later.

## Validation

- Verified the USB path now uses `SPIEXT_LSOP_GET_BUS(ls_op_addr)` consistently for all SPI bus-indexed arrays
- Confirmed this matches the PCIe transport's indexing pattern in `pcie_uram_main.c`
- Confirmed `SPIEXT_LSOP_GET_BUS()` result is already bounds-checked at line 166
- Build verification: clean build with gcc 15.2.0, zero warnings

## Hardware follow-up

- If USB hardware is available, exercise SPI read/write transactions on a device using the USB transport path (e.g., LMS7002M register access)