### PR TITLE
usdr_dm_create: fix TX generator format check

### DIFF
--- a/src/tools/usdr_dm_create.c
+++ b/src/tools/usdr_dm_create.c
@@ -1146,15 +1146,15 @@ int main(UNUSED int argc, UNUSED char** argv)
             fn_rxtx_thread_t thread_func;
             if(tx_from_file)
                 thread_func = disk_read_thread;
-            else if(strcmp(fmt_rx, SFMT_CI16) == 0 || strcmp(fmt_rx, SFMT_CI16_CI12) == 0)
+            else if(strcmp(fmt_tx, SFMT_CI16) == 0 || strcmp(fmt_tx, SFMT_CI16_CI12) == 0)
                 thread_func = (use_lut) ? freq_gen_thread_ci16_lut : freq_gen_thread_ci16;
-            else if(strcmp(fmt_rx, SFMT_CF32) == 0 || strcmp(fmt_rx, SFMT_CF32_CI12) == 0)
+            else if(strcmp(fmt_tx, SFMT_CF32) == 0 || strcmp(fmt_tx, SFMT_CF32_CI12) == 0)
                 thread_func = freq_gen_thread_cf32;
             else
             {
                 USDR_LOG(LOG_TAG, USDR_LOG_ERROR, "Unable to start TX thread %d: invalid format '%s', "
-                                                  "use -I option to read from file or specify %s/%s data format (-F option) for sine generator",
-                         i, fmt_rx, SFMT_CI16, SFMT_CF32);
+                                                  "use -I option to read from file or specify %s/%s data format (-i option) for sine generator",
+                         i, fmt_tx, SFMT_CI16, SFMT_CF32);
                 goto dev_close;
             }
 


### PR DESCRIPTION
## Summary

In `usdr_dm_create.c`, the TX sine generator thread selection (lines
1149-1157) compares `fmt_rx` (set by `-F`) instead of `fmt_tx` (set by
`-i`). The TX stream itself is correctly created with `fmt_tx` (line 1072),
so when RX and TX formats differ, the TX generator can select the wrong
sample-generation path. The bug is latent when both formats match (the
default case). Also updates the error message to print `fmt_tx` and
reference the TX format option.

## Validation

- Verified `-F` sets `fmt_rx` and `-i` sets `fmt_tx` (lines 796-800)
- Verified TX stream creation already uses `fmt_tx` (line 1072)
- Verified TX sine generator thread selection now uses `fmt_tx` consistently
- Build verification: clean build with gcc 15.2.0, zero warnings

## Behavioral expectation

- No behavior change when `fmt_rx == fmt_tx` (the default and most common usage)
- Correct generator selection when RX and TX formats differ