### PR TITLE
Fix DSDR channel configuration for devices using 3 or 6 converters.

### DIFF
--- a/src/lib/device/m2_dsdr/m2_dsdr.c
+++ b/src/lib/device/m2_dsdr/m2_dsdr.c
@@ -877,25 +877,29 @@ bool dev_m2_dsdr_has_extfe0472(dev_m2_dsdr_t* d)
 int dev_m2_dsdr_lrxnumchans_get(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t* ovalue)
 {
     dev_m2_dsdr_t *d = (dev_m2_dsdr_t *)ud;
-    return d->logic_chcnt_rx;
+    *ovalue = d->logic_chcnt_rx;
+    return 0;
 }
 
 int dev_m2_dsdr_ltxnumchans_get(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t* ovalue)
 {
     dev_m2_dsdr_t *d = (dev_m2_dsdr_t *)ud;
-    return d->logic_chcnt_tx;
+    *ovalue = d->logic_chcnt_tx;
+    return 0;
 }
 
 int dev_m2_dsdr_htxnumchans_get(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t* ovalue)
 {
     dev_m2_dsdr_t *d = (dev_m2_dsdr_t *)ud;
-    return d->hw_chcnt_tx;
+    *ovalue = d->hw_chcnt_tx;
+    return 0;
 }
 
 int dev_m2_dsdr_hrxnumchans_get(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t* ovalue)
 {
     dev_m2_dsdr_t *d = (dev_m2_dsdr_t *)ud;
-    return d->hw_chcnt_rx;
+    *ovalue = d->hw_chcnt_rx;
+    return 0;
 }
 
 int dev_m2_dsdr_rx_enchan(pdevice_t ud, pusdr_vfs_obj_t obj, uint64_t value)

--- a/src/lib/ipblks/streams/sfe_rx_4.c
+++ b/src/lib/ipblks/streams/sfe_rx_4.c
@@ -672,11 +672,21 @@ int exfe_trx4_update_chmap(const sfe_cfg_t* fe,
             unsigned swp_msk = (g + f);
 
             if (complex) {
+                if (newmap->ch_map[f / 2] == 0xff) {
+                    chmap_o[g + f] = g + f;
+                } else {
                 unsigned swap_iq = (newmap->ch_map[f / 2] & CH_SWAP_IQ_FLAG) ? 1 : 0;
+                    unsigned channel = newmap->ch_map[f / 2] & ~CH_SWAP_IQ_FLAG;
                 flag_swap_iq[g + f] = swap_iq;
-                chmap_o[g + f] = (2 * (newmap->ch_map[f / 2] & msk) + ((f % 2) ^ swap_iq));
+                    chmap_o[g + f] = (2 * (channel & msk) + ((f % 2) ^ swap_iq));
+                }
             } else  {
-                chmap_o[g + f] = (newmap->ch_map[f] & msk);
+                if (newmap->ch_map[f] == 0xff) {
+                    chmap_o[g + f] = g + f;
+                } else {
+                    unsigned channel = newmap->ch_map[f] & ~CH_SWAP_IQ_FLAG;
+                    chmap_o[g + f] = (channel & msk);
+                }
             }
             chmap[g + f] = chmap_o[g + f]  ^ (swp_msk);
         }


### PR DESCRIPTION
- Fix DSDR VFS channel count getters to return logical and hardware RX/TX channel counts through the output value instead of the function return code.
- Handle 0xff unmapped channel entries correctly in SFE channel mapping.
- Preserve unmapped channel positions for both complex and real sample modes.
- Separate the channel index from the IQ swap flag before applying channel mapping.